### PR TITLE
Add ChaosSpawn.stop/start

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ end
 
 ## Usage
 
+### Control
+The moment the app is started chaos spawn starts potential killing processes.
+This can be stopped by calling
+```elixir
+  ChaosSpawn.stop
+```
+and then later restarted with:
+```elixir
+  ChaosSpawn.start
+```
+
 ### Usage - in manual spawns
 Use ```ChaosSpawn.Chaotic.Spawn``` in any module you wish to
 have unreliable spawn calls. This will automatically replace the spawn calls

--- a/lib/chaos_spawn.ex
+++ b/lib/chaos_spawn.ex
@@ -7,7 +7,8 @@ defmodule ChaosSpawn do
   alias ChaosSpawn.ProcessSpawner
   alias ChaosSpawn.ProcessWatcher
 
-  @process_watcher_name ChaosSpawn.ProcessWatcher
+  @process_watcher ChaosSpawn.ProcessWatcher
+  @process_killer ChaosSpawn.ProcessKiller
 
   def start(_type, _args) do
     ChaosSpawn.Supervisor.start_link
@@ -16,18 +17,25 @@ defmodule ChaosSpawn do
   # For convience provide all 6 spawning functions
   for spawn_fun <- [:spawn, :spawn_link, :spawn_monitor] do
     def unquote(spawn_fun)(module, fun, args) do
-      args = [module, fun, args, @process_watcher_name]
+      args = [module, fun, args, @process_watcher]
       apply(ProcessSpawner, unquote(spawn_fun), args)
     end
 
     def unquote(spawn_fun)(fun) do
-      apply(ProcessSpawner, unquote(spawn_fun), [fun, @process_watcher_name])
+      apply(ProcessSpawner, unquote(spawn_fun), [fun, @process_watcher])
     end
   end
 
   def register_process(pid) do
-    ProcessWatcher.add_pid(@process_watcher_name, pid)
+    ProcessWatcher.add_pid(@process_watcher, pid)
   end
 
+  def stop do
+    send @process_killer, {:switch_off}
+  end
+
+  def start do
+    send @process_killer, {:switch_on}
+  end
 
 end

--- a/lib/chaos_spawn/supervisor.ex
+++ b/lib/chaos_spawn/supervisor.ex
@@ -8,7 +8,8 @@ defmodule ChaosSpawn.Supervisor do
     Supervisor.start_link(__MODULE__, :ok)
   end
 
-  @process_watcher_name ChaosSpawn.ProcessWatcher
+  @process_watcher ChaosSpawn.ProcessWatcher
+  @process_killer ChaosSpawn.ProcessKiller
 
   @process_tidy_up_tick 2000 #2 seconds
 
@@ -17,9 +18,9 @@ defmodule ChaosSpawn.Supervisor do
 
   def init(:ok) do
     children = [
-      worker(ChaosSpawn.ProcessWatcher, [[name: @process_watcher_name]]),
+      worker(ChaosSpawn.ProcessWatcher, [[name: @process_watcher]]),
       worker(ChaosSpawn.ProcessKiller,
-        [kill_tick, kill_prob, @process_watcher_name]
+        [kill_tick, kill_prob, @process_watcher, [name: @process_killer]]
       ),
       worker(Task, [&tidy_pid_list/0])
     ]
@@ -36,7 +37,7 @@ defmodule ChaosSpawn.Supervisor do
 
   defp tidy_pid_list do
     :timer.sleep(@process_tidy_up_tick)
-    ChaosSpawn.ProcessWatcher.tidy_pids(@process_watcher_name)
+    ChaosSpawn.ProcessWatcher.tidy_pids(@process_watcher)
     tidy_pid_list
   end
 end


### PR DESCRIPTION
Fixes #2 
The killer process, which is now named, listens to messages and switches on/off.
Trigger using `ChaosSpawn.start/0` and `ChaosSpawn.stop/0`
